### PR TITLE
fix: correct export syntax for PriceChart and TokenIcon in Murphy com…

### DIFF
--- a/components/ui/murphy/index.tsx
+++ b/components/ui/murphy/index.tsx
@@ -43,6 +43,6 @@ export {
   PKInput,
   PriceChange,
   Sparkline,
-  PriceChart
-  TokenIcon
+  PriceChart,
+  TokenIcon,
 };


### PR DESCRIPTION
…ponent